### PR TITLE
Fix case when using framework.assets.base_path

### DIFF
--- a/Routing/ImagineLoader.php
+++ b/Routing/ImagineLoader.php
@@ -49,7 +49,7 @@ class ImagineLoader extends Loader
     {
         $requirements = ['_methods' => 'GET', 'filter' => '[A-z0-9_\-]*', 'path' => '.+'];
         $defaults     = ['_controller' => 'imagine.controller:filterAction'];
-        $routeSuffix  = $host ? '_' . preg_replace('#[^a-z0-9]+#i', '_', $host) : '';
+        $routeSuffix  = '_' . preg_replace('#[^a-z0-9]+#i', '_', $host);
 
         $routes->add(
             '_imagine_' . $filter . $routeSuffix,


### PR DESCRIPTION
Fix case when using framework.assets.base_path instead of base_urls. In
that case host is empty, however internals are still expecting
underscore (no need for ternary operator when preparing route name).
